### PR TITLE
Feat/release notes

### DIFF
--- a/.github/workflows/integrated-pipeline.yml
+++ b/.github/workflows/integrated-pipeline.yml
@@ -2,9 +2,9 @@ name: Integrated CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, master, develop, stage, staging ]
+    branches: [ main, master, develop, stage, staging, FEAT/Release-notes ]
   pull_request:
-    branches: [ main, master, develop, stage ]
+    branches: [ main, master, develop, stage, FEAT/Release-notes ]
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,0 +1,66 @@
+name: Generate Release Notes Draft
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Rama sobre la que generar release notes (main/master)'
+        required: true
+        default: 'main'
+      previous_tag:
+        description: 'Tag anterior (opcional, detecta automáticamente si vacío)'
+        required: false
+        default: ''
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine previous tag
+        id: prev
+        run: |
+          if [ -n "${{ github.event.inputs.previous_tag }}" ]; then
+            echo "tag=${{ github.event.inputs.previous_tag }}" >> $GITHUB_OUTPUT
+          else
+            LAST=$(git describe --tags --abbrev=0 || echo '')
+            echo "tag=$LAST" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Generate notes
+        id: notes
+        run: |
+          FROM=${{ steps.prev.outputs.tag }}
+          if [ -z "$FROM" ]; then
+            echo "No previous tag, tomando todos los commits" >&2
+            git log --pretty=format:'- %s (%h)' > RELEASE_NOTES_DRAFT.md
+          else
+            git log $FROM..${{ github.event.inputs.target_branch }} --pretty=format:'- %s (%h)' > RELEASE_NOTES_DRAFT.md
+          fi
+          echo "draft<<EOF" >> $GITHUB_OUTPUT
+          cat RELEASE_NOTES_DRAFT.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes-draft
+          path: RELEASE_NOTES_DRAFT.md
+
+      - name: Crear issue con borrador (opcional)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const draft = `# Draft Release Notes\n${{ steps.notes.outputs.draft }}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Release Notes Draft',
+              body: draft,
+              labels: ['release','draft']
+            });
+

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -7,6 +7,7 @@ on:
       - master
       - develop
       - stage
+      - FEAT/Release-notes
 
 jobs:
   release:
@@ -33,4 +34,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: semantic-release
-

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -27,8 +27,15 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install semantic-release
-        run: npm i -g semantic-release @semantic-release/changelog @semantic-release/git @semantic-release/github @semantic-release/commit-analyzer @semantic-release/release-notes-generator
+      - name: Install semantic-release and plugins
+        run: |
+          npm i -g semantic-release \
+            @semantic-release/changelog \
+            @semantic-release/git \
+            @semantic-release/github \
+            @semantic-release/commit-analyzer \
+            @semantic-release/release-notes-generator \
+            conventional-changelog-conventionalcommits
 
       - name: Release
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,6 +9,10 @@
     {
       "name": "stage",
       "prerelease": "rc"
+    },
+    {
+      "name": "FEAT/Release-notes",
+      "prerelease": "notes"
     }
   ],
   "tagFormat": "v${version}",

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,9 +11,20 @@
       "prerelease": "rc"
     }
   ],
+  "tagFormat": "v${version}",
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
     [
       "@semantic-release/changelog",
       {
@@ -23,8 +34,10 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "assets": [
+          "CHANGELOG.md"
+        ],
+        "message": "chore(release): v${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
     "@semantic-release/github"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+Todas las notas de versión se generan automáticamente mediante semantic-release.
+
+## [Unreleased]
+- Inicialización de versionado semántico.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,45 @@
+## 1.0.0-notes.1 (2025-11-23)
+
+### Features
+
+* Add initial Terraform Azure infrastructure ([c05e7e9](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/c05e7e96e4fa43564f9e0a8a70465bb5caabd1bd))
+* Add kubeconfig and update cloud-config with probes ([5365c7b](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/5365c7b474411ab1defa92cc47309c25f53ef80d))
+* Add Kubernetes manifests for ecommerce microservices ([2b89df1](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/2b89df1fb8da689985d0d6624b60398d8cc6841d))
+* Add release automation and change management docs ([ec7f271](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/ec7f27130d002c3f13a06763b3d5e37773aabe48))
+* Add semantic release, notifications, and gated deploy workflows ([4178879](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/4178879af6e2e7351daa94e93293762218134ff2))
+* Add SonarQube and Trivy code quality integration ([0143da9](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/0143da9b53f65e99e7f1637850809a47935d53b7))
+* Add stage environment Docker and script files ([d6c0b36](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/d6c0b363a811fd5240c45052db8c9961b0e893fc))
+* Expose API Gateway via NodePort and enhance config overrides ([525199a](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/525199a668fe799280317b466ba384578e792484))
+* Improve service startup order and readiness checks ([fb4fa5b](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/fb4fa5b10684860dc0b4a806927726cb83d40ab5))
+* johanaguirre's taller 2 & alejoamu's taller 2 integration ([cd0c474](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/cd0c474342ac783627579d24bd76563bc9ea3188))
+* Refactor Docker Compose for core/app separation and network ([b8eccd9](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/b8eccd900ca7a544eca327f80d45cf1622d59427))
+* Refactor Terraform infra to modular multi-env structure ([20033dd](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/20033ddf6e75e4976be1ac0f3826d9c20b54b9a5))
+* **release-notes:** probar fix de preset conventionalcommits ([9054d04](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/9054d04d6fb24f5c3f26bde5c8ddc9c177f0c0f5))
+* **release-notes:** probar generacion de notas en rama feat ([acbb869](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/acbb869e9bcb2a5d0446565ce622a1914909d2dc))
+* Remove GitHub Actions CI/CD workflows and add Ansible setup ([a08962f](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/a08962f2ee77af9e4069d4cb31948c077f06fdc9))
+* Remove Jenkins, add Locust and Trivy to CI stack ([0e268be](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/0e268befc5f7e10787734310c7e4dd03ccc18a43))
+
+### Bug Fixes
+
+* Add explicit bash shell and improve directory creation in CI ([ab0d7e9](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/ab0d7e93ec40b261b3c8ce3c543198ffa47d583b))
+* Add index.html generation for unit-integration and locust reports ([0919844](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/0919844dd698abc395c84cad2151259dac0c03a3))
+* Add Java 11 setup and Maven build to CI workflow ([40e5ae8](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/40e5ae87bcb1c307960ba50b7b7239639acb2d6e))
+* Add k8s manifests for ecommerce microservices ([9b06362](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/9b063620692e8d2b9bc67ef70cf4ebae914917ce))
+* Add product-service startup and readiness check ([7be3ecb](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/7be3ecb0d47ec296b5e404d92628f32bd6e63fcb))
+* Ensure directory exists before creating index.html ([43f3fdd](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/43f3fdd2b4700c2a0f5ca23dce3527f735056dd4))
+* Improve CI workflows with better readiness checks ([3b44271](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/3b44271b6e2382abc0ed70d40258c5751ef77f4f))
+* Improve e2e workflow port-forwarding and diagnostics ([872c9d7](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/872c9d7a1dc2bcd3ee874f0baefed48967703c83))
+* Make Locust endpoints configurable via environment variables ([952ae8f](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/952ae8faf246ad9243a842cade42b65ba33a8dff))
+* Remove indentation from here-doc HTML in CI workflow ([5e89730](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/5e897308faa547c466b2a549e36576a848df8b28))
+* Replace heredoc with printf for HTML file generation ([81360e7](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/81360e7e946d268bb0fd0a023f2a35a5a5ed999d))
+* Set explicit host for Locust tests ([749444b](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/749444bec28b967d578892dfd493ffdbb7bc0850))
+* solve issues with acces points ([8db7c78](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/8db7c78d694af0b93defa4ccf92ad65b3658c0b1))
+* Update Eureka and config env vars in compose files ([5ef3d63](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/5ef3d63703dd92050614b552436338b0be62964e))
+* Update kubectl version command in workflow ([fd6bd0f](https://github.com/alejoamu/Proyecto-final-Ingesoft-V/commit/fd6bd0f0f91fb9c285ebfa2af68b637852aab490))
+
 # Changelog
 
 Todas las notas de versión se generan automáticamente mediante semantic-release.
 
 ## [Unreleased]
 - Inicialización de versionado semántico.
-

--- a/Docs/CHANGE_MANAGEMENT.md
+++ b/Docs/CHANGE_MANAGEMENT.md
@@ -1,0 +1,76 @@
+# Proceso Formal de Change Management
+
+## Objetivos
+Gestionar cambios de manera controlada garantizando trazabilidad, evaluación de impacto, aprobación y rollback seguro.
+
+## Roles
+- Product Owner: prioriza cambios.
+- Tech Lead: evalúa impacto técnico y riesgos.
+- QA / Tester: valida criterios de aceptación y pruebas.
+- Release Manager: autoriza despliegue a producción.
+
+## Flujo de Cambio
+1. Registro (Change Request):
+   - Crear Issue con etiqueta `change-request` describiendo: motivo, alcance, impacto esperado.
+2. Clasificación:
+   - Tipo: Funcional, Técnica, Seguridad, Hotfix.
+   - Criticidad: Baja, Media, Alta.
+3. Evaluación:
+   - Tech Lead agrega análisis: componentes afectados, migraciones, riesgos, esfuerzo (story points o horas), dependencias externas.
+4. Aprobación:
+   - Product Owner y Release Manager revisan y etiquetan `approved-for-dev`.
+5. Implementación (Dev):
+   - Branch convención: `feature/<cambio>` o `fix/<cambio>`.
+   - Commits con Conventional Commits (ej. `feat: ...`, `fix: ...`).
+6. QA / Validación:
+   - Ejecutar pruebas unitarias, integración, e2e, performance si aplica.
+   - Si pasa, etiquetar Issue con `ready-for-stage`.
+7. Stage / Pre-Producción:
+   - Despliegue vía workflow `deploy-gated.yml` a stage.
+   - Ejecutar smoke + pruebas funcionales focalizadas.
+   - Etiquetar Issue `ready-for-prod`.
+8. Producción:
+   - Aprobación manual (environment protegido) antes de job de producción.
+   - Despliegue automático; registrar versión y actualizar CHANGELOG.
+9. Post-Implementation Review:
+   - Verificar métricas (errores, logs, rendimiento) en las primeras horas.
+   - Marcar Issue `closed` si todo OK.
+
+## Criterios de Aprobación
+- Código revisado (PR con al menos 1 reviewer técnico).
+- Cobertura >= objetivo (ej. 60%).
+- 0 vulnerabilidades HIGH/CRITICAL nuevas.
+- Quality Gate en Sonar: Passed.
+- Pruebas E2E clave: Passed.
+
+## Documentación asociada
+- Impacto: en Issue inicial.
+- Diseño técnico: adjuntar diagrama/archivo en `Docs/` si es cambio mayor.
+- Rollback plan: referencia a `Docs/ROLLBACK_PLAN.md`.
+
+## Herramientas Soportadas
+- GitHub Issues & Projects para backlog.
+- GitHub Actions (workflows: semantic-release, deploy-gated, integrated pipeline).
+- SonarQube para calidad.
+- Trivy para seguridad.
+
+## Métricas
+- Lead Time del cambio: tiempo desde `change-request` abierto a Release.
+- Número de cambios urgentes (hotfix) por sprint.
+- Ratio de cambios revertidos.
+- Tiempo medio de rollback.
+
+## Etiquetas Estándar
+`change-request`, `approved-for-dev`, `ready-for-stage`, `ready-for-prod`, `hotfix`, `security`, `rollback-required`, `release`, `draft`.
+
+## Escalamiento
+- Si el cambio implica riesgo alto (seguridad crítica, impacto financiero), se requiere reunión formal y firma (comentario `@release-manager` y `@product-owner`).
+
+## Automatización Integrada
+- Versionado semántico: genera tag y release automáticamente según commits.
+- Draft release notes: workflow `release-draft.yml`.
+- Notificaciones: `notifications.yml` alerta fallos + snippet de errores.
+
+## Revisión Periódica
+- Trimestral: revisar proceso, ajustar métricas y umbrales (cobertura, vulnerabilidades). 
+

--- a/Docs/RELEASE_TAGGING.md
+++ b/Docs/RELEASE_TAGGING.md
@@ -1,0 +1,70 @@
+# Sistema de Etiquetado de Releases
+
+## Convención de Tags
+- Formato estándar: `v<major>.<minor>.<patch>` (ej: `v1.4.2`).
+- Pre-releases:
+  - Beta (develop): `v1.5.0-beta.<incremento>`.
+  - Release Candidate (stage): `v1.5.0-rc.<incremento>`.
+
+## Generación Automática
+- semantic-release crea tags según tipo de commit:
+  - `feat:` → incrementa minor.
+  - `fix:` → incrementa patch.
+  - `feat!` o `BREAKING CHANGE:` → incrementa major.
+  - Otros (docs, chore, refactor) no incrementan versión salvo breaking.
+
+## Pasos para un Release Estándar
+1. Merge de PRs a `develop` con commits convencionales.
+2. Pipeline semantic-release en `develop` genera pre-release `beta` (opcional para pruebas tempranas).
+3. Merge a `stage` → genera `rc` y se despliega a stage (aprobaciones manuales).
+4. Merge a `main` → genera release final `vX.Y.Z` + GitHub Release + actualización de `CHANGELOG.md`.
+
+## Draft Manual de Release Notes
+- Ejecutar workflow `Generate Release Notes Draft` (`release-draft.yml`), revisa Issue creado.
+- Ajustar texto si se necesita (agregar secciones: Highlights, Breaking Changes, Upgrade Notes).
+
+## Estructura Recomendada de Release Notes
+```
+## vX.Y.Z - YYYY-MM-DD
+### Highlights
+- Nueva funcionalidad ...
+### Fixes
+- Corregido bug ...
+### Performance
+- Optimizado ...
+### Security
+- Actualizado dependencia ...
+### Breaking Changes
+- Cambio en contrato API / endpoint removido
+### Upgrade Notes
+- Ejecutar migración DB V2025_03__add_column.sql antes de iniciar servicio
+```
+
+## Etiquetas en Issues/PR
+- `release` : PR que prepara cambios finales.
+- `breaking-change` : marcar cuando hay cambios incompatibles.
+- `needs-docs` : requiere actualización de documentación.
+
+## Rollback de Tag
+- Si un release es retirado: crear tag `vX.Y.Z-yanked` o usar GitHub Release "Mark as pre-release" + Issue de rollback.
+- Revert commits del release y ejecutar nueva versión patch/hotfix.
+
+## Verificación Post-Release
+- Confirmar tag creado: `git fetch --tags && git tag -l | grep vX.Y.Z`.
+- Revisar Release en GitHub (assets, notas). 
+- Validar CHANGELOG actualizado (última sección corresponde a la versión nueva).
+
+## Integración con CI de Docker
+- Tags semver aplicados a imágenes: `ghcr.io/<org>/ecommerce/<service>:vX.Y.Z` y alias mayor-menor `vX.Y`.
+- Último release también puede etiquetarse como `latest` (agregar en metadata-action si se requiere).
+
+## Buenas Prácticas
+- No fusionar commits sin convención (evita versión incorrecta o salto inesperado).
+- Revisión de PR: validar que no haya breaking ocultos sin anotación.
+- Documentar Breaking Changes en los commit messages o en la descripción del PR.
+
+## Tooling Complementario
+- commitlint (pendiente) para validar mensajes.
+- Release please (alternativa) si se decide migrar de semantic-release.
+
+

--- a/Docs/ROLLBACK_PLAN.md
+++ b/Docs/ROLLBACK_PLAN.md
@@ -1,0 +1,79 @@
+# Plan de Rollback
+
+## Objetivo
+Definir procedimientos rápidos y seguros para revertir despliegues problemáticos minimizando impacto.
+
+## Triggers de Rollback
+- Degradación de métricas críticas (latencia > umbral, errores 5xx > X%).
+- Fallo funcional grave (endpoint principal no responde).
+- Descubrimiento de vulnerabilidad crítica post-deploy.
+- Incumplimiento del SLA en primeros N minutos.
+
+## Estrategias
+1. **Reversión de Tag/Imagen**:
+   - Mantener siempre la imagen anterior etiquetada: `service:previous`.
+   - Despliegue: `kubectl set image deployment/<svc> <container>=<registry>/<svc>:previous`.
+2. **Git Revert**:
+   - `git revert <commit_del_release>` → fuerza nueva ejecución de CI con versión correctiva (hotfix).
+3. **Rollback de Base de Datos**:
+   - Migraciones Flyway: versionar scripts reversibles. Si migración irreversible, aplicar script de compensación.
+   - Backup automático antes de deploy (snapshot). Restaurar snapshot si la migración rompe integridad.
+4. **Config Server**:
+   - Mantener copia de configs previas (`config-rollback-<fecha>.yml`).
+   - Reaplicar y refrescar: `curl -X POST http://cloud-config/actuator/refresh`.
+5. **Feature Flags**:
+   - Para cambios grandes, envolver en bandera. Rollback lógico: desactivar flag sin revertir código.
+
+## Procedimiento Paso a Paso
+1. Detectar incidente y clasificar severidad.
+2. Notificar en Slack canal `#incidentes` con: versión, servicios afectados, métrica.
+3. Seleccionar estrategia:
+   - Solo imagen nueva falla → reversión de imagen.
+   - Código introdujo bug crítico → git revert + redeploy.
+   - Migración DB rota → restaurar backup + revertir imagen.
+4. Ejecutar rollback.
+5. Validar estado (smoke tests + health endpoints).
+6. Registrar en Issue original con etiqueta `rollback-required` y comentario final.
+7. Crear post-mortem si severidad alta (documentar causa raíz, mejoras preventivas).
+
+## Comandos Útiles
+```bash
+# Ver versión desplegada (anotada en label)
+kubectl get deploy <svc> -o jsonpath='{.metadata.labels.version}'
+
+# Rollback imagen
+docker pull <registry>/<svc>:previous
+kubectl set image deployment/<svc> <svc>=<registry>/<svc>:previous --record
+
+# Revert commit
+git revert <hash>
+git push origin main
+
+# Restaurar migraciones (ejemplo)
+# Aplicar script down si existe
+psql -f V20250221__down.sql
+```
+
+## Validación Post-Rollback
+- Health actuators: HTTP 200.
+- Métricas APM: latencia vuelve a baseline.
+- Errores 5xx reducidos < umbral.
+
+## Métricas a Monitorear Durante Rollback
+- Tiempo total de ejecución del rollback.
+- Tiempo de detección (TTD) + Tiempo de recuperación (TTR).
+- Incidentes por tipo de estrategia aplicativo vs infra.
+
+## Prevención
+- Canary deployments (porcentaje de tráfico controlado antes de rollout completo).
+- Tests automáticos de migraciones en entorno staging con snapshot real.
+- Monitoring y alertado más granular (Resilience4j metrics, Prometheus alert rules).
+
+## Checklist Rápido
+- [ ] Identificado el motivo.
+- [ ] Elegida estrategia.
+- [ ] Ejecutado rollback.
+- [ ] Verificado estado.
+- [ ] Documentado en Issue.
+- [ ] Post-mortem (si aplica).
+


### PR DESCRIPTION
This pull request introduces a comprehensive change management and release process for the project, focusing on automated semantic versioning, release notes generation, and robust rollback procedures. It adds documentation for change management, release tagging, and rollback plans, and enhances CI/CD workflows to support a new release notes feature branch, improved semantic-release configuration, and a workflow for generating draft release notes. The changelog is also updated with a new pre-release version and detailed commit history.

**Release & Change Management Process**

* Added formal documentation for change management (`Docs/CHANGE_MANAGEMENT.md`), release tagging conventions (`Docs/RELEASE_TAGGING.md`), and rollback procedures (`Docs/ROLLBACK_PLAN.md`) to standardize workflow and improve traceability. [[1]](diffhunk://#diff-e0af5fc70eb0f75dbb8a752fd3a3ef5a65baeae12938e5d0822fb4fbb8a4775aR1-R76) [[2]](diffhunk://#diff-e0f3a5fdecf92335b9a4fd799f52961dd9e6011f8f2ee02175168a26198b1113R1-R70) [[3]](diffhunk://#diff-1171d826165b1a14bd2bf72faac6956c47ef8326a8155782b689c5bbc374ecfeR1-R79)

**CI/CD Workflow Enhancements**

* Updated CI/CD workflows (`.github/workflows/integrated-pipeline.yml`, `.github/workflows/semantic-release.yml`) to support the new `FEAT/Release-notes` branch for release automation and semantic versioning. Semantic-release and plugins installation is improved for better changelog and release notes generation. [[1]](diffhunk://#diff-b25cd6efc83dadf9f21c8c07c7ed8d9435e079923637c07953a736a5a3e42da0L5-R7) [[2]](diffhunk://#diff-ea3710a52b3ef06a333289cb6d30d80091cde61d7f198ca449e463a6a52e4d39R10) [[3]](diffhunk://#diff-ea3710a52b3ef06a333289cb6d30d80091cde61d7f198ca449e463a6a52e4d39L29-L36)

* Added a new workflow (`.github/workflows/release-draft.yml`) to generate draft release notes, including automatic detection of previous tags and creation of a GitHub issue with the draft.

**Semantic-release Configuration**

* Extended `.releaserc.json` to support the `FEAT/Release-notes` branch, enforce conventional commit presets, and use a standardized tag format (`v${version}`) for releases. The release message now includes the version prefix for clarity. [[1]](diffhunk://#diff-e774e90e159e39c0a392fffa584ea8520508a9a0c10468d0bd685800e28a42f5R12-R31) [[2]](diffhunk://#diff-e774e90e159e39c0a392fffa584ea8520508a9a0c10468d0bd685800e28a42f5L26-R44)

**Changelog Update**

* Updated `CHANGELOG.md` with a new pre-release version `1.0.0-notes.1`, listing all recent features and bug fixes generated automatically via semantic-release.